### PR TITLE
Added OSQP_NON_CVX flag

### DIFF
--- a/extension/include/osqpobjectpy.h
+++ b/extension/include/osqpobjectpy.h
@@ -44,6 +44,9 @@ static PyObject * OSQP_solve(OSQP *self)
 		// Create status object
 		PyObject * status;
 
+        // Create obj_val object
+		PyObject * obj_val;
+
 		// Create solution objects
 		PyObject * x, *y, *prim_inf_cert, *dual_inf_cert;
 
@@ -115,22 +118,29 @@ static PyObject * OSQP_solve(OSQP *self)
 		// Store status string
 		status = PyUnicode_FromString(self->workspace->info->status);
 
+        // Store obj_val
+        if (self->workspace->info->status_val == OSQP_NON_CVX) {	// non convex
+		    obj_val = PyFloat_FromDouble(Py_NAN);
+        } else {
+            obj_val = PyFloat_FromDouble(self->workspace->info->obj_val);
+        }
+
 		// Create info_list
 #ifdef PROFILING
 #ifdef DLONG
 
 #ifdef DFLOAT
-		argparse_string = "LOLLfffffffLf";
+		argparse_string = "LOLLOffffffLf";
 #else
-		argparse_string = "LOLLdddddddLd";
+		argparse_string = "LOLLOddddddLd";
 #endif
 
 #else
 
 #ifdef DFLOAT
-		argparse_string = "iOiifffffffif";
+		argparse_string = "iOiiOffffffif";
 #else
-		argparse_string = "iOiidddddddid";
+		argparse_string = "iOiiOddddddid";
 #endif
 
 #endif
@@ -140,7 +150,7 @@ static PyObject * OSQP_solve(OSQP *self)
 				status,
 				self->workspace->info->status_val,
 				self->workspace->info->status_polish,
-				self->workspace->info->obj_val,
+                obj_val,
 				self->workspace->info->pri_res,
 				self->workspace->info->dua_res,
 				self->workspace->info->setup_time,
@@ -155,17 +165,17 @@ static PyObject * OSQP_solve(OSQP *self)
 #ifdef DLONG
 
 #ifdef DFLOAT
-		argparse_string = "LOLLfffLf";
+		argparse_string = "LOLLOffLf";
 #else
-		argparse_string = "LOLLdddLd";
+		argparse_string = "LOLLOddLd";
 #endif
 
 #else
 
 #ifdef DFLOAT
-		argparse_string = "iOiifffif";
+		argparse_string = "iOiiOffif";
 #else
-		argparse_string = "iOiidddid";
+		argparse_string = "iOiiOddid";
 #endif
 
 #endif
@@ -175,7 +185,7 @@ static PyObject * OSQP_solve(OSQP *self)
 				status,
 				self->workspace->info->status_val,
 				self->workspace->info->status_polish,
-				self->workspace->info->obj_val,
+				obj_val,
 				self->workspace->info->pri_res,
 				self->workspace->info->dua_res,
 				self->workspace->info->rho_updates,
@@ -342,9 +352,9 @@ static PyObject *OSQP_constant(OSQP *self, PyObject *args) {
 
     if(!strcmp(constant_name, "OSQP_NAN")){
         #ifdef DFLOAT
-        return Py_BuildValue("f", OSQP_NAN);
+        return Py_BuildValue("f", Py_NAN);
         #else
-        return Py_BuildValue("d", OSQP_NAN);
+        return Py_BuildValue("d", Py_NAN);
         #endif
     }
 
@@ -352,7 +362,7 @@ static PyObject *OSQP_constant(OSQP *self, PyObject *args) {
         return Py_BuildValue("i", OSQP_SOLVED);
     }
 
-		if(!strcmp(constant_name, "OSQP_SOLVED_INACCURATE")){
+	if(!strcmp(constant_name, "OSQP_SOLVED_INACCURATE")){
         return Py_BuildValue("i", OSQP_SOLVED_INACCURATE);
     }
 
@@ -364,20 +374,24 @@ static PyObject *OSQP_constant(OSQP *self, PyObject *args) {
         return Py_BuildValue("i", OSQP_PRIMAL_INFEASIBLE);
     }
 
-		if(!strcmp(constant_name, "OSQP_PRIMAL_INFEASIBLE_INACCURATE")){
-				return Py_BuildValue("i", OSQP_PRIMAL_INFEASIBLE_INACCURATE);
-		}
+	if(!strcmp(constant_name, "OSQP_PRIMAL_INFEASIBLE_INACCURATE")){
+			return Py_BuildValue("i", OSQP_PRIMAL_INFEASIBLE_INACCURATE);
+	}
 
     if(!strcmp(constant_name, "OSQP_DUAL_INFEASIBLE")){
         return Py_BuildValue("i", OSQP_DUAL_INFEASIBLE);
     }
 
-		if(!strcmp(constant_name, "OSQP_DUAL_INFEASIBLE_INACCURATE")){
-				return Py_BuildValue("i", OSQP_DUAL_INFEASIBLE_INACCURATE);
-		}
+	if(!strcmp(constant_name, "OSQP_DUAL_INFEASIBLE_INACCURATE")){
+		return Py_BuildValue("i", OSQP_DUAL_INFEASIBLE_INACCURATE);
+	}
 
     if(!strcmp(constant_name, "OSQP_MAX_ITER_REACHED")){
         return Py_BuildValue("i", OSQP_MAX_ITER_REACHED);
+    }
+
+    if(!strcmp(constant_name, "OSQP_NON_CVX")){
+        return Py_BuildValue("i", OSQP_NON_CVX);
     }
 
     if(!strcmp(constant_name, "OSQP_TIME_LIMIT_REACHED")){

--- a/module/tests/non_convex_test.py
+++ b/module/tests/non_convex_test.py
@@ -1,0 +1,33 @@
+# Test osqp python module
+import osqp
+# import osqppurepy as osqp
+import numpy as np
+from scipy import sparse
+
+# Unit Test
+import unittest
+import numpy.testing as nptest
+
+class non_convex_tests(unittest.TestCase):
+
+    def setUp(self):
+
+        # Simple QP problem
+        self.P = sparse.csc_matrix([[2., 5.], [5., 1.]])
+        self.q = np.array([3, 4])
+        self.A = sparse.csc_matrix([[-1.0, 0.], [0., -1.], [-1., 3.], [2., 5.], [3., 4]])
+        self.u = np.array([0., 0., -15, 100, 80])
+        self.l = -np.inf * np.ones(len(self.u))
+        self.opts = {'verbose': False}
+        self.model = osqp.OSQP()
+        self.model.setup(P=self.P, q=self.q, A=self.A, l=self.l, u=self.u,
+                         **self.opts)
+
+    def test_non_convex(self):
+        # Solve problem
+        res = self.model.solve()
+
+        # Assert close
+        self.assertEqual(res.info.status_val, self.model.constant('OSQP_NON_CVX'))
+        nptest.assert_approx_equal(res.info.obj_val, self.model.constant('OSQP_NAN'))
+

--- a/module/tests/non_convex_test.py
+++ b/module/tests/non_convex_test.py
@@ -13,15 +13,14 @@ class non_convex_tests(unittest.TestCase):
     def setUp(self):
 
         # Simple QP problem
-        self.P = sparse.csc_matrix([[2., 5.], [5., 1.]])
-        self.q = np.array([3, 4])
-        self.A = sparse.csc_matrix([[-1.0, 0.], [0., -1.], [-1., 3.], [2., 5.], [3., 4]])
-        self.u = np.array([0., 0., -15, 100, 80])
-        self.l = -np.inf * np.ones(len(self.u))
-        self.opts = {'verbose': False}
+        P = sparse.csc_matrix([[2., 5.], [5., 1.]])
+        q = np.array([3, 4])
+        A = sparse.csc_matrix([[-1.0, 0.], [0., -1.], [-1., 3.], [2., 5.], [3., 4]])
+        u = np.array([0., 0., -15, 100, 80])
+        l = -np.inf * np.ones(len(u))
+        opts = {'verbose': False}
         self.model = osqp.OSQP()
-        self.model.setup(P=self.P, q=self.q, A=self.A, l=self.l, u=self.u,
-                         **self.opts)
+        self.model.setup(P=P, q=q, A=A, l=l, u=u, **opts)
 
     def test_non_convex(self):
         # Solve problem
@@ -29,5 +28,8 @@ class non_convex_tests(unittest.TestCase):
 
         # Assert close
         self.assertEqual(res.info.status_val, self.model.constant('OSQP_NON_CVX'))
-        nptest.assert_approx_equal(res.info.obj_val, self.model.constant('OSQP_NAN'))
+        nptest.assert_approx_equal(res.info.obj_val, np.nan)
+
+    def test_nan(self):
+        nptest.assert_approx_equal(self.model.constant('OSQP_NAN'), np.nan)
 


### PR DESCRIPTION
- Made some edits in the `osqpobjectpy.h` file in order to handle `NaN` in the objective value when the solver status value is `OSQP_NON_CVX`.
- Made some edits in pure Python implementation to match the C one.
- Added a unit test when the problem is non-convex.