### PR TITLE
Fix primal infeasibility check

### DIFF
--- a/module/tests/dual_infeasibility_test.py
+++ b/module/tests/dual_infeasibility_test.py
@@ -88,5 +88,5 @@ class dual_infeasibility_tests(unittest.TestCase):
         res = self.model.solve()
 
         # Assert close
-        self.assertEqual(res.info.status_val,
-                         self.model.constant('OSQP_DUAL_INFEASIBLE'))
+        self.assertIn(res.info.status_val, [self.model.constant('OSQP_PRIMAL_INFEASIBLE'),
+                                            self.model.constant('OSQP_DUAL_INFEASIBLE')])

--- a/module/tests/primal_infeasibility_test.py
+++ b/module/tests/primal_infeasibility_test.py
@@ -75,5 +75,5 @@ class primal_infeeasibility_tests(unittest.TestCase):
         res = self.model.solve()
 
         # Assert close
-        self.assertEqual(res.info.status_val,
-                         self.model.constant('OSQP_PRIMAL_INFEASIBLE'))
+        self.assertIn(res.info.status_val, [self.model.constant('OSQP_PRIMAL_INFEASIBLE'),
+                                            self.model.constant('OSQP_DUAL_INFEASIBLE')])


### PR DESCRIPTION
This is a Python example of an infeasible problem from https://github.com/oxfordcontrol/osqp/issues/144

Download [data.zip](https://github.com/oxfordcontrol/osqp-python/files/3212803/data.zip) and run:

```python
import osqp
import numpy as np
from scipy import sparse
import zipfile

with zipfile.ZipFile('./data.zip', 'r') as zip_ref:
    zip_ref.extractall('./')

# Load matrices from npz files
P = sparse.load_npz("data_P.npz")
A = sparse.load_npz("data_A.npz")

# Load vectors from npz file
vec = np.load("data_vec.npz")
q = vec['q']
l = vec['l']
u = vec['u']

# Run OSQP
prob = osqp.OSQP()
prob.setup(P, q, A, l, u)
res = prob.solve()
```