### PR TITLE
use pyporject.toml to install setup dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - source $HOME/miniconda/bin/activate
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
-  - conda install conda conda-verify conda-build
+  - conda install conda conda-verify conda-build numpy
   - conda info -a
 
 script:
@@ -39,4 +39,3 @@ script:
 #       - conda install anaconda-client
 #       - anaconda -t $ANACONDA_TOKEN upload $HOME/miniconda/conda-bld/**/*.tar.bz2 --user oxfordcontrol --force
 #     skip_cleanup: true
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - if "%PLATFORM%"=="x64" set MINICONDA=C:\Miniconda3-x64
   - call %MINICONDA%\Scripts\activate
   - conda.exe config --append channels conda-forge
-  - conda.exe install conda conda-verify conda-build vs2008_express_vc_python_patch --yes
+  - conda.exe install conda conda-verify conda-build vs2008_express_vc_python_patch numpy --yes
   # Fix for 64-bit Python 2.7 builds, courtesy vs2008_express_vc_python_patch
   - call %MINICONDA%\Scripts\setup_x64.bat
 

--- a/module/codegen/files_to_generate/setup.py
+++ b/module/codegen/files_to_generate/setup.py
@@ -1,20 +1,11 @@
-import distutils.sysconfig as sysconfig
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-from platform import system
-from glob import glob
 import os
 import shutil as sh
+from glob import glob
+from platform import system
 from subprocess import call
 
-
-class build_ext_osqp(build_ext):
-    def finalize_options(self):
-        build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
+import numpy
+from setuptools import setup, Extension
 
 
 '''
@@ -56,7 +47,7 @@ if system() == 'Linux':
 '''
 Include directory
 '''
-include_dirs = [os.path.join('..', 'include')]  # OSQP includes
+include_dirs = [os.path.join('..', 'include'), numpy.get_include()]  # OSQP includes
 
 '''
 Source files
@@ -82,5 +73,4 @@ setup(name='PYTHON_EXT_NAME',
       setup_requires=["numpy >= 1.7"],
       install_requires=["numpy >= 1.7", "future"],
       license='Apache 2.0',
-      cmdclass={'build_ext': build_ext_osqp},
       ext_modules=[PYTHON_EXT_NAME])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["numpy >= 1.7", "setuptools>=40.8.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 from __future__ import print_function
+
 import distutils.sysconfig as sysconfig
+import os
+import shutil as sh
+import sys
+from glob import glob
+from platform import system
+from shutil import copyfile, copy
+from subprocess import call, check_output
+
+import numpy
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from shutil import copyfile, copy
-from glob import glob
-import shutil as sh
-from subprocess import call, check_output
-from platform import system
-import os
-import sys
 
 
 # Add parameters to cmake_args and define_macros
@@ -58,7 +61,8 @@ include_dirs = [
                                             # extract workspace for codegen
     os.path.join(qdldl_dir, "qdldl_sources",
                             "include"),     # qdldl includes for file types
-    os.path.join('extension', 'include')]   # auxiliary .h files
+    os.path.join('extension', 'include'),   # auxiliary .h files
+    numpy.get_include()]                    # numpy header files
 
 sources_files = glob(os.path.join('extension', 'src', '*.c'))
 
@@ -140,13 +144,6 @@ for f in configure_files:  # Copy configure files
 
 
 class build_ext_osqp(build_ext):
-    def finalize_options(self):
-        build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
     def build_extensions(self):
         # Compile OSQP using CMake
 


### PR DESCRIPTION
we need `numpy` installed before `setup.py` is opened to build `osqp`
extension. PEP 518 enables this by using `pyproject.toml` file that
has a list of build-system requirements. `pip >= 10` support PEP 518.

fixes https://github.com/oxfordcontrol/osqp/issues/167