### PR TITLE
Fixed a typo in codegen

### DIFF
--- a/module/codegen/code_generator.py
+++ b/module/codegen/code_generator.py
@@ -144,7 +144,7 @@ def codegen(work, target_dir, python_ext_name, project_type, embedded,
     sh.copy(os.path.join(osqp_path, 'codegen', 'sources', 'src', 'CMakeLists.txt'),
             os.path.join(target_src_dir, 'osqp'))
     sh.copy(os.path.join(osqp_path, 'codegen', 'sources', 'include', 'CMakeLists.txt'),
-            os.path.join(target_include_dir, 'osqp'))
+            os.path.join(target_include_dir))
 
     # Copy example.c
     sh.copy(os.path.join(files_to_generate_path, 'example.c'), target_src_dir)


### PR DESCRIPTION
When running the example posted in https://github.com/oxfordcontrol/osqp/issues/177, I got the following CMake error:
```
Getting workspace from OSQP object...                           [done]
Creating target directories...                                  [done]
Copying OSQP sources...                                         [done]
Generating customized code...                                   [done]
Compiling Python wrapper...                                     CMake Error at CMakeLists.txt:120 (add_subdirectory):
  The source directory

    C:/Users/goran/Documents/code/python/osqp-python/code/include

  does not contain a CMakeLists.txt file.
```
This should be fixed with this PR.