### PR TITLE
Include warning package

### DIFF
--- a/module/codegen/code_generator.py
+++ b/module/codegen/code_generator.py
@@ -144,7 +144,7 @@ def codegen(work, target_dir, python_ext_name, project_type, embedded,
     sh.copy(os.path.join(osqp_path, 'codegen', 'sources', 'src', 'CMakeLists.txt'),
             os.path.join(target_src_dir, 'osqp'))
     sh.copy(os.path.join(osqp_path, 'codegen', 'sources', 'include', 'CMakeLists.txt'),
-            os.path.join(target_include_dir, 'osqp'))
+            os.path.join(target_include_dir))
 
     # Copy example.c
     sh.copy(os.path.join(files_to_generate_path, 'example.c'), target_src_dir)

--- a/module/utils.py
+++ b/module/utils.py
@@ -1,4 +1,5 @@
 """Common utility functions"""
+from warnings import warn
 import numpy as np
 import scipy.sparse as sparse
 import osqp._osqp as _osqp


### PR DESCRIPTION
Otherwise, it throws `NameError: name 'warn' is not defined`.