### PR TITLE
fix(requirements): install future only if python version <= 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy >= 1.7
 scipy >= 0.13.2
-future
+future;python_version<="2.7"


### PR DESCRIPTION
See [issue 34](https://github.com/oxfordcontrol/osqp-python/issues/34) by @wkschwartz