### PR TITLE
Update version to 0.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,7 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(name='osqp',
-      version='0.6.1',
+      version='0.6.2',
       author='Bartolomeo Stellato, Goran Banjac',
       author_email='bartolomeo.stellato@gmail.com',
       description='OSQP: The Operator Splitting QP Solver',


### PR DESCRIPTION
## Motivation

The 0.6.1 release of OSQP on Pypi is broken for packages that depend on it.
See for instance https://github.com/sebp/scikit-survival/pull/98#issuecomment-599042564

Apparently it has been fixed after it.
Could you please set the package version to 0.6.2 and release it with the fixes ?