### PR TITLE
Preventing empty array declarations with code generation

### DIFF
--- a/module/codegen/utils.py
+++ b/module/codegen/utils.py
@@ -66,8 +66,7 @@ def write_mat_extern(f, mat, name):
     """
     Write matrix prototype to file
     """
-    if len(mat['x']) > 0:
-        f.write("extern csc %s;\n" % name)
+    f.write("extern csc %s;\n" % name)
 
 
 def write_data_src(f, data):


### PR DESCRIPTION
In the case of linear programs, the `csc` matrix `P` is empty. Previously, amongst others, empty (zero length) index and data arrays for `P` were generated. Some compilers will throw an error because of this. This pull request prevents the declaration of empty arrays and specifies `NULL` pointers where needed.