### PR TITLE
Update cibuildwheel to latest version

### DIFF
--- a/.github/workflows/build_cuda.yml
+++ b/.github/workflows/build_cuda.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       with:
         package-dir: backend/cuda
         config-file: backend/cuda/cibuildwheel.toml

--- a/.github/workflows/build_cuda_windows.yml
+++ b/.github/workflows/build_cuda_windows.yml
@@ -51,7 +51,7 @@ jobs:
         del %TEMP%\cuda.exe
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       with:
         package-dir: backend/cuda
         config-file: backend/cuda/cibuildwheel.toml

--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       with:
         config-file: cibuildwheel.toml
         output-dir: wheelhouse

--- a/.github/workflows/build_mkl.yml
+++ b/.github/workflows/build_mkl.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       with:
         package-dir: backend/mkl
         config-file: backend/mkl/cibuildwheel.toml

--- a/.github/workflows/build_mkl_windows.yml
+++ b/.github/workflows/build_mkl_windows.yml
@@ -49,7 +49,7 @@ jobs:
         rd /s/q "webimage_base_extracted"
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       with:
         package-dir: backend/mkl
         config-file: backend/mkl/cibuildwheel.toml

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.3
       env:
         CIBW_PLATFORM: pyodide
       with:

--- a/backend/cuda/cibuildwheel.toml
+++ b/backend/cuda/cibuildwheel.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp36-*", "cp37-*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*"]
 build-verbosity = 1
 before-build = "rm -rf {package}/osqp_sources/build"
 repair-wheel-command = ""

--- a/backend/cuda/cibuildwheel.toml
+++ b/backend/cuda/cibuildwheel.toml
@@ -7,9 +7,9 @@ repair-wheel-command = ""
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo",
-  "yum search cuda-toolkit*",
-  "yum install -y cuda-toolkit-12-6"
+  "dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo",
+  "dnf search cuda-toolkit*",
+  "dnf install -y cuda-toolkit-12-6"
 ]
 environment = { CMAKE_CUDA_COMPILER = "/usr/local/cuda-12.6/bin/nvcc" }
 

--- a/backend/cuda/cibuildwheel.toml
+++ b/backend/cuda/cibuildwheel.toml
@@ -9,9 +9,9 @@ repair-wheel-command = ""
 before-all = [
   "dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo",
   "dnf search cuda-toolkit*",
-  "dnf install -y cuda-toolkit-12-6"
+  "dnf install -y cuda-toolkit-12-8"
 ]
-environment = { CMAKE_CUDA_COMPILER = "/usr/local/cuda-12.6/bin/nvcc" }
+environment = { CMAKE_CUDA_COMPILER = "/usr/local/cuda-12.8/bin/nvcc" }
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_CUDA_COMPILER = "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6/bin/nvcc.exe", CUDA_TOOLKIT_ROOT_DIR = "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6", CMAKE_GENERATOR_TOOLSET = "cuda=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.6" }

--- a/backend/mkl/cibuildwheel.toml
+++ b/backend/mkl/cibuildwheel.toml
@@ -6,9 +6,9 @@ before-build = "rm -rf {package}/osqp_sources/build"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "yum-config-manager --add-repo https://yum.repos.intel.com/oneapi",
+  "dnf config-manager --add-repo https://yum.repos.intel.com/oneapi",
   "rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB",
-  "yum --nogpgcheck install -y intel-oneapi-mkl-devel-2023.0.0"
+  "dnf --nogpgcheck install -y intel-oneapi-mkl-devel-2025.0"
 ]
 environment = { MKL_ROOT = "/opt/intel/oneapi/mkl/latest" }
 repair-wheel-command = ""
@@ -16,6 +16,7 @@ repair-wheel-command = ""
 [tool.cibuildwheel.macos]
 before-all = [
   # See https://github.com/oneapi-src/oneapi-ci for installer URLs
+  # macOS must use an old version because newer versions dropped compatibility for x86-based macOS
   "wget -q https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd013e6c-49c4-488b-8b86-25df6693a9b7/m_BaseKit_p_2023.2.0.49398.dmg",
   "hdiutil attach -noverify -noautofsck m_BaseKit_p_2023.2.0.49398.dmg",
   "sudo /Volumes/m_BaseKit_p_2023.2.0.49398/bootstrapper.app/Contents/MacOS/bootstrapper --silent --eula accept --components intel.oneapi.mac.mkl.devel",

--- a/backend/mkl/cibuildwheel.toml
+++ b/backend/mkl/cibuildwheel.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp36-*", "cp37-*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*"]
 build-verbosity = 1
 before-build = "rm -rf {package}/osqp_sources/build"
 

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp36-*", "cp37-*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*"]
 build-verbosity = 1
 before-build = "rm -rf {package}/osqp_sources/build"
 # Install CPU-only version of torch beforehand since that allows cibuildwheel


### PR DESCRIPTION
This updates our cibuildwheel version to the latest, so we get support for new Python versions. They dropped Python <3.8 support, so we no longer need to skip the tests on those. They also appear to have increased the default manylinux image version, so we need to use dnf to install our dependencies instead of yum now.