### PR TITLE
Add wheel for Windows ARM64

### DIFF
--- a/.github/workflows/build_default.yml
+++ b/.github/workflows/build_default.yml
@@ -46,6 +46,8 @@ jobs:
             cibw_archs: "auto"
           - os: windows-2022
             cibw_archs: "auto64"
+          - os: windows-11-arm
+            cibw_archs: "ARM64"
           # Include macos-15-intel to get Intel x86_64 macs and macos-latest to get the Aaarch64 macs
           - os: macos-15-intel
             cibw_archs: "x86_64"

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,6 +1,7 @@
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp313t-*", "cp314t-*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+# Numpy and Scipy are not available on Python 3.9/3.10 for Windows ARM64
+skip = ["cp313t-*", "cp314t-*", "*-win32", "*-manylinux_i686", "*-musllinux_*", "cp39-win_arm64", "cp310-win_arm64"]
 build-verbosity = 1
 before-build = "rm -rf {package}/osqp_sources/build"
 # Install CPU-only version of torch beforehand since that allows cibuildwheel


### PR DESCRIPTION
This adds building a wheel for Windows ARM64 using the GitHub-hosted runners. Scipy and Numpy are only available 3.11+, so we have to limit our supported versions to those as well.

Fixes https://github.com/osqp/osqp-python/issues/200