### PR TITLE
Suppress redundant conversion warnings for scipy csc_array (#214)

### DIFF
--- a/src/osqp/interface.py
+++ b/src/osqp/interface.py
@@ -25,6 +25,14 @@ _ALGEBRA_MODULES = {
 OSQP_ALGEBRA_BACKEND = os.environ.get('OSQP_ALGEBRA_BACKEND')  # If envvar is set, that algebra is used by default
 
 
+def is_csc(sp_mat):
+    """Check if the sparse matrix or array is in the csc format."""
+    if hasattr(spa, 'csc_array'):
+        return isinstance(sp_mat, (spa.csc_matrix, spa.csc_array))
+    else:
+        return isinstance(sp_mat, spa.csc_matrix)
+
+
 def algebra_available(algebra):
     assert algebra in _ALGEBRAS, f'Unknown algebra {algebra}'
     module = _ALGEBRA_MODULES[algebra]
@@ -222,10 +230,10 @@ class OSQP:
             P = spa.triu(P, format='csc')
 
         # Convert matrices in CSC form to individual pointers
-        if not spa.isspmatrix_csc(P):
+        if not is_csc(P):
             warnings.warn('Converting sparse P to a CSC matrix. This may take a while...')
             P = P.tocsc()
-        if not spa.isspmatrix_csc(A):
+        if not is_csc(A):
             warnings.warn('Converting sparse A to a CSC matrix. This may take a while...')
             A = A.tocsc()
 

--- a/src/osqppurepy/interface.py
+++ b/src/osqppurepy/interface.py
@@ -8,6 +8,14 @@ import numpy as np
 from scipy import sparse
 
 
+def is_csc(sp_mat):
+    """Check if the sparse matrix or array is in the csc format."""
+    if hasattr(sparse, 'csc_array'):
+        return isinstance(sp_mat, (sparse.csc_matrix, sparse.csc_array))
+    else:
+        return isinstance(sp_mat, sparse.csc_matrix)
+
+
 class OSQP(object):
     def __init__(self):
         self._model = _osqp.OSQP()
@@ -104,10 +112,10 @@ class OSQP(object):
             raise TypeError('A is required to be a sparse matrix')
 
         # Convert matrices in CSC form and to individual pointers
-        if not sparse.isspmatrix_csc(P):
+        if not is_csc(P):
             warn('Converting sparse P to a CSC ' + '(compressed sparse column) matrix. (It may take a while...)')
             P = P.tocsc()
-        if not sparse.isspmatrix_csc(A):
+        if not is_csc(A):
             warn('Converting sparse A to a CSC ' + '(compressed sparse column) matrix. (It may take a while...)')
             A = A.tocsc()
 


### PR DESCRIPTION
Fix #214 