### PR TITLE
Let pybind11 modules release the GIL when used with free-threaded Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11>=2.13"]
+requires = ["scikit-build-core", "pybind11>=3.0.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -20,9 +20,12 @@ authors = [
 dependencies = [
     "jinja2",
     "numpy>=1.7",
+    "numpy>=2.1.0; python_version >= '3.14'",
     "scipy>=0.13.2",
+    "scipy>=1.15.2; python_version >= '3.14'",
     "setuptools",
     "joblib",
+    "joblib>=1.4.2; python_version >= '3.14'",
 ]
 
 [project.urls]

--- a/src/bindings.cpp.in
+++ b/src/bindings.cpp.in
@@ -313,7 +313,7 @@ OSQPInt PyOSQPSolver::codegen(const char *output_dir, const char *file_prefix, O
     return osqp_codegen(this->_solver, output_dir, file_prefix, &defines);
 }
 
-PYBIND11_MODULE(@OSQP_EXT_MODULE_NAME@, m) {
+PYBIND11_MODULE(@OSQP_EXT_MODULE_NAME@, m, py::mod_gil_not_used()) {
 
 #ifdef OSQP_USE_FLOAT
     m.attr("OSQP_USE_FLOAT") = 1;

--- a/src/osqp/codegen/pywrapper/bindings.cpp.jinja
+++ b/src/osqp/codegen/pywrapper/bindings.cpp.jinja
@@ -90,7 +90,7 @@ OSQPInt update_data_mat(py::object P_x, py::object P_i, py::object A_x, py::obje
 }
 #endif
 
-PYBIND11_MODULE({{extension_name}}, m) {
+PYBIND11_MODULE({{extension_name}}, m, py::mod_gil_not_used()) {
     m.def("solve", &solve);
     m.def("update_data_vec", &update_data_vec, "Update q/l/u", py::arg("q") = py::none(), py::arg("l") = py::none(), py::arg("u") = py::none());
 #if OSQP_EMBEDDED_MODE == 2


### PR DESCRIPTION
While free-threading wheels are being built, the pybind11 modules currently do not release the GIL. Therefore, when running osqp with free-threaded Python, one gets the warning:

```
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'osqp.ext_builtin', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
```

This pull request releases the GIL, based on https://pybind11.readthedocs.io/en/stable/advanced/misc.html#free-threading-support

Minimum required version for dependencies have been raised to versions that added support for free-threaded Python when using Python 3.14 or later.